### PR TITLE
Add CC compatible coroutine API

### DIFF
--- a/scripts/api/generator.lua
+++ b/scripts/api/generator.lua
@@ -37,7 +37,7 @@ function Generator:run()
     while self.runTask do
         self.runTask = false
         local task = results[1]
-        isActive, results = splitFirst( self:resume( task(table.unpack(results, 2)) ) )
+        isActive, results = splitFirst(self:resume(task(table.unpack(results, 2))))
     end
 
     return table.unpack(results)

--- a/scripts/api/generator.lua
+++ b/scripts/api/generator.lua
@@ -1,0 +1,64 @@
+local function splitFirst(first, ...)
+    return first, { ... }
+end
+
+local Generator = {}
+Generator.__index = Generator
+
+function Generator.new(co)
+    local instance = {
+        co = co,
+        runTask = false
+    }
+
+    instance.yield = function(...)
+        return coroutine.yield(...)
+    end
+
+    instance.exec = function(callback, ...)
+        instance.runTask = true
+        return coroutine.yield(callback, ...)
+    end
+
+    return setmetatable(instance, Generator)
+end
+
+function Generator.from(toExecute)
+    local co = coroutine.create(toExecute)
+    return Generator.new(co)
+end
+
+function Generator:run()
+    local isActive, results = splitFirst(self:resume(self.yield, self.exec))
+    if not isActive then
+        return nil
+    end
+
+    while self.runTask do
+        self.runTask = false
+        local task = results[1]
+        isActive, results = splitFirst( self:resume( task(table.unpack(results, 2)) ) )
+    end
+
+    return table.unpack(results)
+end
+
+function Generator:resume(...)
+    return coroutine.resume(self.co, ...)
+end
+
+function Generator:close()
+    return coroutine.close(self.co)
+end
+
+function Generator:dead()
+    return coroutine.status(self.co) == "dead"
+end
+
+return {
+    routine = Generator.from,
+    create = function(toExecute)
+        local generator = Generator.from(toExecute)
+        return function() return generator:run() end
+    end
+}


### PR DESCRIPTION
CC functions which interact with the MC world cause any coroutine to abrutly stop and be unrecoverable. 

The generator API provides a friendly consumer and performant API to execute a function outside of the coroutine. 
A full coroutine-like API can be used or for more common scenarios a simply 'run' function which can be used like an iterator